### PR TITLE
CAV-113: Create and Store GovNotify Account API Keys

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -122,6 +122,10 @@ microservice {
       host = localhost
       port = 8500
     }
+    
+    govuk-notify {
+      api-key = TBC
+    }
   }
 }
 


### PR DESCRIPTION
 - added placeholder value for govuk-notify api key