### PR TITLE
CAV-164 - Add explicit audit events for the phone verification process

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumberverification/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/audit/AuditEvent.scala
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.audit
 
-import java.security.SecureRandom
-import javax.inject.Singleton
-import scala.collection.mutable
+abstract class AuditEvent(phoneNumber: String, passcode: String)
 
-@Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
-  }
-}

--- a/app/uk/gov/hmrc/cipphonenumberverification/audit/AuditType.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/audit/AuditType.scala
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.audit
 
-import java.security.SecureRandom
-import javax.inject.Singleton
-import scala.collection.mutable
-
-@Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
-  }
+object AuditType extends Enumeration {
+  val PHONE_NUMBER_VERIFICATION_REQUEST: AuditType.Value = Value("PhoneNumberVerificationRequest")
+  val PHONE_NUMBER_VERIFICATION_DELIVERY_RESULT_REQUEST: AuditType.Value = Value("PhoneNumberVerificationDeliveryResultRequest")
+  val PHONE_NUMBER_VERIFICATION_CHECK: AuditType.Value = Value("PhoneNumberVerificationCheck")
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationCheckAuditEvent.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationCheckAuditEvent.scala
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.models
+package uk.gov.hmrc.cipphonenumberverification.audit
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json}
 
-case class GovUkNotificationStatus(status: String)
+case class VerificationCheckAuditEvent(phoneNumber: String, passcode: String, result: String) extends AuditEvent(phoneNumber, passcode)
 
-object GovUkNotificationStatus {
-  implicit val reads: Reads[GovUkNotificationStatus] = Json.reads[GovUkNotificationStatus]
+object VerificationCheckAuditEvent {
+
+  implicit val writes = Json.writes[VerificationCheckAuditEvent]
 }
+

--- a/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationDeliveryResultRequestAuditEvent.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationDeliveryResultRequestAuditEvent.scala
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.audit
 
-import java.security.SecureRandom
-import javax.inject.Singleton
-import scala.collection.mutable
+import play.api.libs.json.{Json}
 
-@Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
-  }
+case class VerificationDeliveryResultRequestAuditEvent(phoneNumber: String, passcode: String, notificationId: String,
+                                                                  notificationStatus: String) extends AuditEvent(phoneNumber, passcode)
+
+object VerificationDeliveryResultRequestAuditEvent {
+  implicit val writes = Json.writes[VerificationDeliveryResultRequestAuditEvent]
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationRequestAuditEvent.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/audit/VerificationRequestAuditEvent.scala
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.audit
 
-import java.security.SecureRandom
-import javax.inject.Singleton
-import scala.collection.mutable
+import play.api.libs.json.{Json}
 
-@Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
-  }
+case class VerificationRequestAuditEvent(phoneNumber: String, passcode: String) extends AuditEvent(phoneNumber, passcode)
+
+object VerificationRequestAuditEvent {
+  implicit val writes = Json.writes[VerificationRequestAuditEvent]
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/models/govnotify/response/GovUkNotificationStatusResponse.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/models/govnotify/response/GovUkNotificationStatusResponse.scala
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.models.govnotify.response
 
-import java.security.SecureRandom
-import javax.inject.Singleton
-import scala.collection.mutable
+import play.api.libs.json.{Json, Reads}
 
-@Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
-  }
+case class GovUkNotificationStatusResponse(phone_number: String, body: String, status: String)
+
+object GovUkNotificationStatusResponse {
+  implicit val reads: Reads[GovUkNotificationStatusResponse] = Json.reads[GovUkNotificationStatusResponse]
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/services/AuditService.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/AuditService.scala
@@ -16,20 +16,23 @@
 
 package uk.gov.hmrc.cipphonenumberverification.services
 
-import java.security.SecureRandom
+import com.google.inject.Inject
+import play.api.Logging
+import play.api.libs.json.{Writes}
+import uk.gov.hmrc.cipphonenumberverification.audit.{AuditEvent}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
 import javax.inject.Singleton
-import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 
 @Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
+class AuditService @Inject()(auditConnector: AuditConnector
+                            )(implicit ec: ExecutionContext) extends Logging {
+
+  def sendExplicitAuditEvent[T <: AuditEvent](auditType: String, auditEvent: T)(implicit hc: HeaderCarrier, writes: Writes[T]): Unit = {
+    logger.debug(s"Sending explicit audit event for $auditEvent")
+    auditConnector.sendExplicitAudit(auditType, auditEvent)
   }
+
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/services/PasscodeService.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/PasscodeService.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.cipphonenumberverification.services
 
 import play.api.Logging
-import uk.gov.hmrc.cipphonenumberverification.models.PhoneNumberAndOtp
+import uk.gov.hmrc.cipphonenumberverification.models.{PhoneNumberAndOtp}
 import uk.gov.hmrc.cipphonenumberverification.repositories.PasscodeCacheRepository
 import uk.gov.hmrc.mongo.cache.DataKey
 
@@ -26,11 +26,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PasscodeService @Inject()(passcodeCacheRepository: PasscodeCacheRepository)
                                (implicit ec: ExecutionContext) extends Logging {
-  def persistPasscode(phoneNumber: String): Future[PhoneNumberAndOtp] = {
-    logger.debug(s"Storing phoneNumberAndOtp in database for $phoneNumber")
-    val otp = OtpService.otpGenerator
-    val phoneNumberAndOtp = PhoneNumberAndOtp(phoneNumber, otp)
-    passcodeCacheRepository.put(phoneNumber)(DataKey("cip-phone-number-verification"), phoneNumberAndOtp)
+  def persistPasscode(phoneNumberAndOtp: PhoneNumberAndOtp): Future[PhoneNumberAndOtp] = {
+    logger.debug(s"Storing phoneNumberAndOtp in database for ${phoneNumberAndOtp.phoneNumber}")
+    passcodeCacheRepository.put(phoneNumberAndOtp.phoneNumber)(DataKey("cip-phone-number-verification"), phoneNumberAndOtp)
       .map(_ => phoneNumberAndOtp)
   }
 

--- a/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyHelper.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyHelper.scala
@@ -20,59 +20,57 @@ import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.{Accepted, BadRequest, InternalServerError, Ok}
+import uk.gov.hmrc.cipphonenumberverification.audit.{AuditType, VerificationCheckAuditEvent, VerificationRequestAuditEvent}
 import uk.gov.hmrc.cipphonenumberverification.connectors.GovUkConnector
 import uk.gov.hmrc.cipphonenumberverification.models._
 import uk.gov.hmrc.http.HttpReads.{is2xx, is4xx}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
-abstract class VerifyHelper @Inject()(passcodeService: PasscodeService, govUkConnector: GovUkConnector) extends Logging {
+abstract class VerifyHelper @Inject()(otpService: OtpService, auditService: AuditService, passcodeService: PasscodeService, govUkConnector: GovUkConnector)(implicit ec: ExecutionContext) extends Logging {
 
   protected def processResponse(res: HttpResponse)(implicit hc: HeaderCarrier): Future[Result] = res match {
-    case _ if is2xx(res.status) => processValidPhoneNumber(res.json.as[ValidatedPhoneNumber])
+    case _ if is2xx(res.status) => processPhoneNumber(res.json.as[ValidatedPhoneNumber])
     case _ if is4xx(res.status) => Future(BadRequest(res.json))
   }
 
-  protected def processResponseForOtp(res: HttpResponse, phoneNumberAndOtp: PhoneNumberAndOtp): Future[Result] = res match {
+  protected def processResponseForOtp(res: HttpResponse, phoneNumberAndOtp: PhoneNumberAndOtp)(implicit hc: HeaderCarrier): Future[Result] = res match {
     case _ if is2xx(res.status) => processValidOtp(res.json.as[ValidatedPhoneNumber], phoneNumberAndOtp.otp)
     case _ if is4xx(res.status) => Future(BadRequest(res.json))
   }
 
-  private def processValidPhoneNumber(validatedPhoneNumber: ValidatedPhoneNumber)
-                                     (implicit hc: HeaderCarrier) = validatedPhoneNumber.phoneNumberType match {
-    case "Mobile" =>
-      passcodeService.persistPasscode(validatedPhoneNumber.phoneNumber) flatMap sendPasscode recover {
-        case err =>
-          logger.error(s"Database operation failed - ${err.getMessage}")
-          InternalServerError(Json.toJson(ErrorResponse("DATABASE_OPERATION_FAIL", "Database operation failed")))
-      }
-    case _ => Future(Ok(Json.toJson(Indeterminate("Indeterminate", "Only mobile numbers can be verified"))))
-  }
-
-  private def processPasscode(enteredPhoneNumberAndOtp: PhoneNumberAndOtp,
-                              maybePhoneNumberAndOtp: Option[PhoneNumberAndOtp]): Future[Result] = maybePhoneNumberAndOtp match {
-    case Some(storedPhoneNumberAndOtp)
-      if enteredPhoneNumberAndOtp.otp.equals(storedPhoneNumberAndOtp.otp) => passcodeService.deletePasscode(enteredPhoneNumberAndOtp) map {
-      _ => Ok(Json.toJson(VerificationStatus("Verified")))
+  private def processPhoneNumber(validatedPhoneNumber: ValidatedPhoneNumber)(implicit hc: HeaderCarrier): Future[Result] = {
+    isPhoneTypeValid(validatedPhoneNumber) match {
+      case true => processValidPhoneNumber(validatedPhoneNumber)
+      case _ => Future(Ok(Json.toJson(Indeterminate("Indeterminate", "Only mobile numbers can be verified"))))
     }
-    case _ => Future.successful(Ok(Json.toJson(VerificationStatus("Not verified"))))
   }
 
-  private def processValidOtp(validatedPhoneNumber: ValidatedPhoneNumber, otp: String) = {
-    (for {
-      maybePhoneNumberAndOtp <- passcodeService.retrievePasscode(validatedPhoneNumber.phoneNumber)
-      result <- processPasscode(PhoneNumberAndOtp(validatedPhoneNumber.phoneNumber, otp), maybePhoneNumberAndOtp)
-    } yield result).recover {
+  private def isPhoneTypeValid(validatedPhoneNumber: ValidatedPhoneNumber)(implicit hc: HeaderCarrier): Boolean = {
+    validatedPhoneNumber.phoneNumberType match {
+      case "Mobile" => true
+      case _ => false
+    }
+  }
+
+  private def processValidPhoneNumber(validatedPhoneNumber: ValidatedPhoneNumber)
+                                     (implicit hc: HeaderCarrier): Future[Result] = {
+    val otp = otpService.otpGenerator()
+    val phoneNumberAndOtp = PhoneNumberAndOtp(validatedPhoneNumber.phoneNumber, otp)
+    auditService.sendExplicitAuditEvent(AuditType.PHONE_NUMBER_VERIFICATION_REQUEST.toString, VerificationRequestAuditEvent(phoneNumberAndOtp.phoneNumber, otp))
+
+    passcodeService.persistPasscode(phoneNumberAndOtp) flatMap sendPasscode recover {
       case err =>
         logger.error(s"Database operation failed - ${err.getMessage}")
         InternalServerError(Json.toJson(ErrorResponse("DATABASE_OPERATION_FAIL", "Database operation failed")))
     }
+
   }
 
-  private def sendPasscode(phoneNumberAndOtp: PhoneNumberAndOtp)(implicit hc: HeaderCarrier) = (govUkConnector.sendPasscode(phoneNumberAndOtp) map {
+  private def sendPasscode(phoneNumberAndOtp: PhoneNumberAndOtp)(implicit hc: HeaderCarrier): Future[Result] = (govUkConnector.sendPasscode(phoneNumberAndOtp) map {
     case Left(_) => ??? //TODO: CAV-163
       logger.error(s"Gov Notify failure - to be covered by CAV-163")
       InternalServerError(Json.toJson(ErrorResponse("EXTERNAL_SYSTEM_FAIL", "sending to Gov Notify failed")))
@@ -82,4 +80,46 @@ abstract class VerifyHelper @Inject()(passcodeService: PasscodeService, govUkCon
       logger.error(s"GOVNOTIFY operation failed - ${err.getMessage}")
       InternalServerError(Json.toJson(ErrorResponse("GOVNOTIFY_OPERATION_FAIL", "Gov Notify operation failed")))
   }
+
+  private def processValidOtp(validatedPhoneNumber: ValidatedPhoneNumber, otp: String)(implicit hc: HeaderCarrier) = {
+    (for {
+      maybePhoneNumberAndOtp <- passcodeService.retrievePasscode(validatedPhoneNumber.phoneNumber)
+      result <- processPasscode(PhoneNumberAndOtp(validatedPhoneNumber.phoneNumber, otp), maybePhoneNumberAndOtp)
+    } yield result).recover {
+      case err =>
+        logger.error(s"Database operation failed - ${err.getMessage}")
+        InternalServerError(Json.toJson(ErrorResponse("DATABASE_OPERATION_FAIL", "Database operation failed")))
+    }
+  }
+  protected def processPasscode(enteredPhoneNumberAndOtp: PhoneNumberAndOtp,
+                                maybePhoneNumberAndOtp: Option[PhoneNumberAndOtp])(implicit hc: HeaderCarrier): Future[Result] =
+    maybePhoneNumberAndOtp match {
+    case Some(storedPhoneNumberAndOtp) => checkIfPasscodeMatches(enteredPhoneNumberAndOtp, storedPhoneNumberAndOtp)(hc)
+    case _ => auditService.sendExplicitAuditEvent(AuditType.PHONE_NUMBER_VERIFICATION_CHECK.toString, VerificationCheckAuditEvent(enteredPhoneNumberAndOtp.phoneNumber, enteredPhoneNumberAndOtp.otp, "Not verified"))
+              Future.successful(Ok(Json.toJson(VerificationStatus("Not verified"))))
+  }
+
+  private def checkIfPasscodeMatches(enteredPhoneNumberAndOtp: PhoneNumberAndOtp,
+                                     maybePhoneNumberAndOtp: PhoneNumberAndOtp)(implicit hc: HeaderCarrier): Future[Result] = {
+    passcodeMatches(enteredPhoneNumberAndOtp.otp, maybePhoneNumberAndOtp.otp) match {
+      case true =>
+        auditService.sendExplicitAuditEvent(AuditType.PHONE_NUMBER_VERIFICATION_CHECK.toString, VerificationCheckAuditEvent(enteredPhoneNumberAndOtp.phoneNumber, enteredPhoneNumberAndOtp.otp, "Verified"))
+        passcodeService.deletePasscode(maybePhoneNumberAndOtp)
+          .transformWith {
+            case Success(result) => Future.successful(Ok(Json.toJson(VerificationStatus("Verified"))))
+            case Failure(exception) =>
+              logger.error(s"Database operation failed - ${exception.getMessage}")
+              Future.successful(InternalServerError(Json.toJson(ErrorResponse("DATABASE_OPERATION_FAIL", "Database operation failed"))))
+          }
+
+      case false => auditService.sendExplicitAuditEvent(AuditType.PHONE_NUMBER_VERIFICATION_CHECK.toString, VerificationCheckAuditEvent(enteredPhoneNumberAndOtp.phoneNumber, enteredPhoneNumberAndOtp.otp, "Not verified"))
+                    Future.successful(Ok(Json.toJson(VerificationStatus("Not verified"))))
+    }
+
+  }
+
+  private def passcodeMatches(enteredPasscode: String, storedPasscode: String): Boolean = {
+    enteredPasscode.equals(storedPasscode)
+  }
+
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyService.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyService.scala
@@ -24,11 +24,13 @@ import uk.gov.hmrc.http.HeaderCarrier
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class VerifyService @Inject()(passcodeService: PasscodeService,
+class VerifyService @Inject()(otpService: OtpService,
+                              auditService: AuditService,
+                              passcodeService: PasscodeService,
                               validatorConnector: ValidateConnector,
                               govUkConnector: GovUkConnector)
                              (implicit val executionContext: ExecutionContext)
-  extends VerifyHelper(passcodeService, govUkConnector) {
+  extends VerifyHelper(otpService, auditService, passcodeService, govUkConnector) {
 
   def verifyPhoneNumber(phoneNumber: PhoneNumber)(implicit hc: HeaderCarrier): Future[Result] =
     for {

--- a/app/uk/gov/hmrc/cipphonenumberverification/utils/GovNotifyUtils.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/utils/GovNotifyUtils.scala
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.utils
 
-import java.security.SecureRandom
 import javax.inject.Singleton
-import scala.collection.mutable
 
 @Singleton()
-class OtpService {
-  def otpGenerator(): String = {
-    val sb = new mutable.StringBuilder()
-    val passcodeSize = 6
-    val chrsToChooseFrom = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    val secureRandom = SecureRandom.getInstanceStrong
-    secureRandom.ints(passcodeSize, 0, chrsToChooseFrom.length)
-      .mapToObj((i: Int) => chrsToChooseFrom.charAt(i))
-      .forEach(x => sb.append(x))
-    sb.mkString
+class GovNotifyUtils {
+
+  def extractPasscodeFromGovNotifyBody(body: String): String = {
+    val sentences: Array[String] = body.split(" ")
+    val thePasscodeAndFullStopAndLineSpace: String = sentences(19)
+    val thePasscode = thePasscodeAndFullStopAndLineSpace.substring(0, 6)
+    thePasscode
   }
 }

--- a/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
@@ -58,8 +58,8 @@ class NotificationIntegrationSpec
           .futureValue
 
       response.status shouldBe 404
-      (response.json \ "code").as[String] shouldBe "NOTIFICATION_NOT_FOUND"
-      (response.json \ "message").as[String] shouldBe "Notification ID not found"
+      (response.json \ "code").as[String] shouldBe "NOT_FOUND"
+      (response.json \ "message").as[String] shouldBe "No_data_found"
     }
   }
 }

--- a/test/uk/gov/hmrc/cipphonenumberverification/controllers/OtpControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/controllers/OtpControllerSpec.scala
@@ -36,6 +36,7 @@ class OtpControllerSpec
     with Matchers
     with IdiomaticMockito {
 
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
   private implicit val writes: OWrites[PhoneNumberAndOtp] = Json.writes[PhoneNumberAndOtp]
   private val fakeRequest = FakeRequest()
   private val mockVerifyService = mock[VerifyService]

--- a/test/uk/gov/hmrc/cipphonenumberverification/data/govNotifyGetMessageStatusResponse.json
+++ b/test/uk/gov/hmrc/cipphonenumberverification/data/govNotifyGetMessageStatusResponse.json
@@ -1,0 +1,6 @@
+{
+  "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
+  "phone_number": "+447900900123",
+  "status": "created",
+  "body": "CIP Phone Number Verification Service: theTaxService needs to verify your telephone number.\n    Your telephone number verification code is ABCDEF.\n    Use this code within 10 minutes to verify your telephone number."
+}

--- a/test/uk/gov/hmrc/cipphonenumberverification/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/services/AuditServiceSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cipphonenumberverification.services
+
+import org.mockito.IdiomaticMockito
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.{Json, OWrites}
+import uk.gov.hmrc.cipphonenumberverification.audit.{AuditType, VerificationRequestAuditEvent}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+
+import scala.concurrent.ExecutionContext
+
+
+class AuditServiceSpec extends AnyWordSpec with Matchers with IdiomaticMockito {
+
+  "sendEvent" should {
+    "send AuditEvent to audit service" in new SetUp {
+      val auditEvent = VerificationRequestAuditEvent("myPhoneNumber", "myPasscode")
+      service.sendExplicitAuditEvent(AuditType.PHONE_NUMBER_VERIFICATION_REQUEST.toString, auditEvent)
+
+      mockAuditConnector.sendExplicitAudit[VerificationRequestAuditEvent](AuditType.PHONE_NUMBER_VERIFICATION_REQUEST.toString, auditEvent)(hc, ex, writes) was called
+    }
+
+  }
+
+  trait SetUp {
+    implicit val writes: OWrites[VerificationRequestAuditEvent] = Json.writes[VerificationRequestAuditEvent]
+    implicit val ex: ExecutionContext = ExecutionContext.global
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val mockAuditConnector = mock[AuditConnector]
+    val service: AuditService = new AuditService(mockAuditConnector)
+  }
+
+}

--- a/test/uk/gov/hmrc/cipphonenumberverification/services/NotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/services/NotificationServiceSpec.scala
@@ -16,137 +16,207 @@
 
 package uk.gov.hmrc.cipphonenumberverification.services
 
+import org.mockito.ArgumentMatchersSugar.any
 import org.mockito.IdiomaticMockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status
-import play.api.libs.json.{Json, OWrites}
+import play.api.libs.json.Format.GenericFormat
+import play.api.libs.json._
 import play.api.test.Helpers._
+import uk.gov.hmrc.cipphonenumberverification.audit.VerificationDeliveryResultRequestAuditEvent
 import uk.gov.hmrc.cipphonenumberverification.connectors.GovUkConnector
-import uk.gov.hmrc.cipphonenumberverification.models.GovUkNotificationStatus
+import uk.gov.hmrc.cipphonenumberverification.models.govnotify.response.GovUkNotificationStatusResponse
+import uk.gov.hmrc.cipphonenumberverification.utils.GovNotifyUtils
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.io.Source
 
 class NotificationServiceSpec extends AnyWordSpec
   with Matchers
   with IdiomaticMockito {
 
-  private implicit val writes: OWrites[GovUkNotificationStatus] = Json.writes[GovUkNotificationStatus]
-  private implicit val hc: HeaderCarrier = HeaderCarrier()
-  private val mockGovUkConnector = mock[GovUkConnector]
-  private val service = new NotificationService(mockGovUkConnector)
-  private val notificationId = "notificationId"
-
   "status" should {
-    "return NotificationStatus for created status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("created")
+    "return NotificationStatus for created status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("created")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 101
       (contentAsJson(result) \ "message").as[String] shouldBe "Message is in the process of being sent"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "created")
+
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for sending status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("sending")
+
+    "return NotificationStatus for sending status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("sending")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 102
       (contentAsJson(result) \ "message").as[String] shouldBe "Message has been sent"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "sending")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for pending status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("pending")
+    "return NotificationStatus for pending status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("pending")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 103
       (contentAsJson(result) \ "message").as[String] shouldBe "Message is in the process of being delivered"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "pending")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for sent (international number) status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("sent")
+    "return NotificationStatus for sent (international number) status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("sent")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 104
       (contentAsJson(result) \ "message").as[String] shouldBe "Message was sent successfully"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "sent")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for delivered status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("delivered")
+    "return NotificationStatus for delivered status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("delivered")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 105
       (contentAsJson(result) \ "message").as[String] shouldBe "Message was delivered successfully"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "delivered")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for permanent-failure status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("permanent-failure")
+    "return NotificationStatus for permanent-failure status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("permanent-failure")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 106
       (contentAsJson(result) \ "message").as[String] shouldBe
         "Message was unable to be delivered by the network provider"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "permanent-failure")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for temporary-failure status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("temporary-failure")
+    "return NotificationStatus for temporary-failure status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("temporary-failure")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 107
       (contentAsJson(result) \ "message").as[String] shouldBe
         "Message was unable to be delivered by the network provider"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "temporary-failure")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus for technical-failure status" in {
-      val govUkNotificationStatus = GovUkNotificationStatus("technical-failure")
+    "return NotificationStatus for technical-failure status" in new SetUp {
+      val govUkNotificationStatus = buildGovNotifyResponseWithStatus("technical-failure")
       val httpResponse = HttpResponse(Status.OK, Json.toJson(govUkNotificationStatus), Map.empty[String, Seq[String]])
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Right(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 200
       (contentAsJson(result) \ "code").as[Int] shouldBe 108
       (contentAsJson(result) \ "message").as[String] shouldBe "There is a problem with the notification vendor"
+      mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, expectedNotificationid, "technical-failure")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
 
-    "return NotificationStatus when notification id not found" in {
+    "return NotificationStatus when notification id not found" in new SetUp {
       val httpResponse = UpstreamErrorResponse("", Status.NOT_FOUND)
       mockGovUkConnector.notificationStatus(notificationId)
         .returns(Future.successful(Left(httpResponse)))
 
       val result = service.status(notificationId)
+
       status(result) shouldBe 404
-      (contentAsJson(result) \ "code").as[String] shouldBe "NOTIFICATION_NOT_FOUND"
-      (contentAsJson(result) \ "message").as[String] shouldBe "Notification ID not found"
+      (contentAsJson(result) \ "code").as[String] shouldBe "NOT_FOUND"
+      (contentAsJson(result) \ "message").as[String] shouldBe "No_data_found"
+      mockGovNotifyUtils wasNever called
+      val expectedVerificationDeliveryResultRequestAuditEvent: VerificationDeliveryResultRequestAuditEvent = VerificationDeliveryResultRequestAuditEvent("No_data_found", "No_data_found", notificationId, "No_data_found")
+      mockAuditService.sendExplicitAuditEvent("PhoneNumberVerificationDeliveryResultRequest", expectedVerificationDeliveryResultRequestAuditEvent) was called
     }
+
   }
+
+  trait SetUp {
+    implicit val writes: OWrites[GovUkNotificationStatusResponse] = Json.writes[GovUkNotificationStatusResponse]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val mockAuditService = mock[AuditService]
+    val mockGovUkConnector = mock[GovUkConnector]
+    val mockGovNotifyUtils = mock[GovNotifyUtils]
+    val service = new NotificationService(mockGovNotifyUtils, mockAuditService, mockGovUkConnector)
+    val notificationId = "740e5834-3a29-46b4-9a6f-16142fde533a"
+    val expectedNotificationid = "740e5834-3a29-46b4-9a6f-16142fde533a"
+    val passcode = "XYZABC"
+    val expectedPhoneNumber = "+447900900123"
+    val expectedGovNotifyResponseBody = "CIP Phone Number Verification Service: theTaxService needs to verify your telephone number.\n    Your telephone number verification code is ABCDEF.\n    Use this code within 10 minutes to verify your telephone number."
+    mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(any[String]).returns(passcode)
+  }
+
+  private def buildGovNotifyResponseWithStatus(status: String): JsValue = {
+    val source: String = Source.fromFile("test/uk/gov/hmrc/cipphonenumberverification/data/govNotifyGetMessageStatusResponse.json").getLines.mkString
+    val json: JsValue = Json.parse(source)
+
+    val jsonTransformerForStatusAndRest = (__).json.update(
+      __.read[JsObject].map { o => o ++ Json.obj("status" -> JsString(status)) }
+    )
+
+    val updatedJsonWithUpdatedStatusAndRest = json.transform(jsonTransformerForStatusAndRest) match {
+      case JsSuccess(x, _) => x
+      case JsError(_) => fail()
+    }
+
+    updatedJsonWithUpdatedStatusAndRest
+  }
+
 }

--- a/test/uk/gov/hmrc/cipphonenumberverification/services/PasscodeServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/services/PasscodeServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.cipphonenumberverification.services
 
-import org.mockito.{ArgumentCaptor, IdiomaticMockito}
+import org.mockito.IdiomaticMockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.JsObject
@@ -34,16 +34,16 @@ class PasscodeServiceSpec extends AnyWordSpec
   with IdiomaticMockito {
 
   "persistPasscode" should {
-    //TODO: We should probably inject the OtpService into the Passcode service
     "return passcode" in new SetUp {
       val phoneNumber = PhoneNumber("test")
-      val phoneNumberAndOtpCaptor = ArgumentCaptor.forClass(classOf[PhoneNumberAndOtp])
-      passcodeCacheRepositoryMock.put(phoneNumber.phoneNumber)(DataKey("cip-phone-number-verification"), phoneNumberAndOtpCaptor.capture())
+      val otp = "ABCDEF"
+      val phoneNumberAndOtpToPersist = PhoneNumberAndOtp(phoneNumber.phoneNumber, otp = otp)
+      passcodeCacheRepositoryMock.put(phoneNumber.phoneNumber)(DataKey("cip-phone-number-verification"), phoneNumberAndOtpToPersist)
         .returns(Future.successful(CacheItem("", JsObject.empty, Instant.EPOCH, Instant.EPOCH)))
-      val result = passcodeService.persistPasscode(phoneNumber.phoneNumber)
-      val phoneNumberAndOtp = phoneNumberAndOtpCaptor.getValue()
 
-      await(result) shouldBe phoneNumberAndOtp
+      val result = passcodeService.persistPasscode(phoneNumberAndOtpToPersist)
+
+      await(result) shouldBe phoneNumberAndOtpToPersist
     }
   }
 

--- a/test/uk/gov/hmrc/cipphonenumberverification/utils/GovNotifyUtilsSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/utils/GovNotifyUtilsSpec.scala
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cipphonenumberverification.services
+package uk.gov.hmrc.cipphonenumberverification.utils
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class OtpServiceSpec extends AnyWordSpec with Matchers{
+class GovNotifyUtilsSpec extends AnyWordSpec with Matchers{
 
-  private val otpService = new OtpService()
+  private val govNotifyUtils = new GovNotifyUtils()
 
-  "create 6 digit passcode" in {
-    otpService.otpGenerator.forall(y => y.isUpper) shouldBe true
-    otpService.otpGenerator.forall(y => y.isLetter) shouldBe true
+  "should extract passcode from GovNotify Body property" in {
+    val input = "CIP Phone Number Verification Service: myTaxService needs to verify your telephone number.\n  Your telephone number verification code is ABCDEF.\n  Use this code within 10 minutes to verify your telephone number."
 
-    val illegalChars = List('@', '£', '$', '%', '^', '&', '*', '(', ')', '-', '+')
-    otpService.otpGenerator.toList map (y => assertResult(illegalChars contains y)(false))
+    val actual = govNotifyUtils.extractPasscodeFromGovNotifyBody(input)
 
-    otpService.otpGenerator.length shouldBe 6
+    actual shouldBe "ABCDEF"
   }
 }


### PR DESCRIPTION
- Added calls to audit service for the 3 explicit audit events.   As described in https://confluence.tools.tax.service.gov.uk/display/CIP/Attribute+Validation+Purple+-+Phone+Number+Verification+API+-+CIP+Assessment
- Added code to unit tests to ensure correct data is being sent to the audit service.
- Refactored verify code a bit to incorporate audit calls and to make it clearer, for example helper methods for is valid type and does passcode match
- Added raw response from GovNotify get notification status call to the unit test data files.
- Updated unit tests to use the raw GovNotify response in order to check the deserialisation.  (as opposed to checking if the code works against an object that has been assumed to have been deserialised correctly).