### PR TITLE
CAV-428: Standardise API responses - notification status endpoint

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumberverification/connectors/ValidateConnector.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/connectors/ValidateConnector.scala
@@ -23,7 +23,7 @@ import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.cipphonenumberverification.config.{AppConfig, CircuitBreakerConfig}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/cipphonenumberverification/models/NotificationStatus.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/models/NotificationStatus.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cipphonenumberverification.models
 
 import play.api.libs.json.{Json, OWrites}
 
-case class NotificationStatus(code: Int, message: String)
+case class NotificationStatus(notificationStatus: String, message: String)
 
 object NotificationStatus {
   implicit val writes: OWrites[NotificationStatus] = Json.writes[NotificationStatus]

--- a/app/uk/gov/hmrc/cipphonenumberverification/services/NotificationService.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/NotificationService.scala
@@ -47,19 +47,19 @@ class NotificationService @Inject()(govNotifyUtils: GovNotifyUtils, auditService
       val phoneNumber = govNotifyResponse.phone_number
       val passcode = govNotifyUtils.extractPasscodeFromGovNotifyBody(govNotifyResponse.body)
       val deliveryStatus = govNotifyResponse.status
-      val (code, message) = deliveryStatus match {
-        case "created" => (101, "Message is in the process of being sent")
-        case "sending" => (102, "Message has been sent")
-        case "pending" => (103, "Message is in the process of being delivered")
-        case "sent" => (104, "Message was sent successfully")
-        case "delivered" => (105, "Message was delivered successfully")
-        case "permanent-failure" => (106, "Message was unable to be delivered by the network provider")
-        case "temporary-failure" => (107, "Message was unable to be delivered by the network provider")
-        case "technical-failure" => (108, "There is a problem with the notification vendor")
+      val (notificationStatus, message) = deliveryStatus match {
+        case "created" => ("CREATED", "Message is in the process of being sent")
+        case "sending" => ("SENDING", "Message has been sent")
+        case "pending" => ("PENDING", "Message is in the process of being delivered")
+        case "sent" => ("SENT", "Message was sent successfully")
+        case "delivered" => ("DELIVERED", "Message was delivered successfully")
+        case "permanent-failure" => ("PERMANENT_FAILURE", "Message was unable to be delivered by the network provider")
+        case "temporary-failure" => ("TEMPORARY_FAILURE", "Message was unable to be delivered by the network provider")
+        case "technical-failure" => ("TECHNICAL_FAILURE", "There is a problem with the notification vendor")
       }
       auditService.sendExplicitAuditEvent(PhoneNumberVerificationDeliveryResultRequest,
         VerificationDeliveryResultRequestAuditEvent(phoneNumber, passcode, notificationId, deliveryStatus))
-      Ok(Json.toJson(NotificationStatus(code, message)))
+      Ok(Json.toJson(NotificationStatus(notificationStatus, message)))
     }
 
     def failure(err: UpstreamErrorResponse) = {

--- a/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
@@ -45,7 +45,7 @@ class NotificationIntegrationSpec
           .futureValue
 
       response.status shouldBe 200
-      (response.json \ "code").as[Int] shouldBe 105
+      (response.json \ "notificationStatus").as[String] shouldBe "DELIVERED"
       (response.json \ "message").as[String] shouldBe "Message was delivered successfully"
     }
 

--- a/test/uk/gov/hmrc/cipphonenumberverification/connectors/CircuitBreakerWrapperSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/connectors/CircuitBreakerWrapperSpec.scala
@@ -17,19 +17,17 @@
 package uk.gov.hmrc.cipphonenumberverification.connectors
 
 import akka.stream.Materializer
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, post, stubFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, stubFor, urlEqualTo}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status.OK
 import play.api.libs.json.Json
-import play.api.libs.ws.ahc.AhcCurlRequestLogger
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.cipphonenumberverification.config.CircuitBreakerConfig
 import uk.gov.hmrc.cipphonenumberverification.utils.TestActorSystem
-import uk.gov.hmrc.http.HttpReadsInstances.readEitherOf
 import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -68,6 +66,7 @@ class CircuitBreakerWrapperSpec extends AnyWordSpec
     protected implicit val hc: HeaderCarrier = HeaderCarrier()
     val circuitBreakers = new CircuitBreakerWrapper {
       override def configCB: CircuitBreakerConfig = CircuitBreakerConfig("Cip Validation", 2, 60.toDuration, 60.toDuration, 60.toDuration, 1, 0)
+
       override def materializer: Materializer = Materializer(TestActorSystem.system)
     }
 

--- a/test/uk/gov/hmrc/cipphonenumberverification/controllers/NotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/controllers/NotificationControllerSpec.scala
@@ -44,12 +44,14 @@ class NotificationControllerSpec extends AnyWordSpec
     "delegate to notification service" in {
       val notificationId = "notificationId"
       mockNotificationsService.status(notificationId)(any[HeaderCarrier])
-        .returns(Future.successful(Ok(Json.toJson(NotificationStatus(1, "test message")))))
+        .returns(Future.successful(Ok(Json.toJson(NotificationStatus("test status", "test message")))))
 
       val result = controller.status(notificationId)(fakeRequest)
       status(result) shouldBe Status.OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 1
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "test status"
       (contentAsJson(result) \ "message").as[String] shouldBe "test message"
+
+      mockNotificationsService.status(notificationId)(any[HeaderCarrier]) was called
     }
   }
 }

--- a/test/uk/gov/hmrc/cipphonenumberverification/services/NotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/services/NotificationServiceSpec.scala
@@ -51,7 +51,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 101
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "CREATED"
       (contentAsJson(result) \ "message").as[String] shouldBe "Message is in the process of being sent"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "created")
@@ -67,7 +67,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 102
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "SENDING"
       (contentAsJson(result) \ "message").as[String] shouldBe "Message has been sent"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "sending")
@@ -83,7 +83,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 103
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "PENDING"
       (contentAsJson(result) \ "message").as[String] shouldBe "Message is in the process of being delivered"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "pending")
@@ -99,7 +99,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 104
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "SENT"
       (contentAsJson(result) \ "message").as[String] shouldBe "Message was sent successfully"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "sent")
@@ -115,7 +115,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 105
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "DELIVERED"
       (contentAsJson(result) \ "message").as[String] shouldBe "Message was delivered successfully"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "delivered")
@@ -131,7 +131,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 106
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "PERMANENT_FAILURE"
       (contentAsJson(result) \ "message").as[String] shouldBe
         "Message was unable to be delivered by the network provider"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
@@ -148,7 +148,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 107
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "TEMPORARY_FAILURE"
       (contentAsJson(result) \ "message").as[String] shouldBe
         "Message was unable to be delivered by the network provider"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
@@ -165,7 +165,7 @@ class NotificationServiceSpec extends AnyWordSpec
       val result = service.status(notificationId)
 
       status(result) shouldBe OK
-      (contentAsJson(result) \ "code").as[Int] shouldBe 108
+      (contentAsJson(result) \ "notificationStatus").as[String] shouldBe "TECHNICAL_FAILURE"
       (contentAsJson(result) \ "message").as[String] shouldBe "There is a problem with the notification vendor"
       mockGovNotifyUtils.extractPasscodeFromGovNotifyBody(expectedGovNotifyResponseBody) was called
       val expectedAuditEvent = VerificationDeliveryResultRequestAuditEvent(expectedPhoneNumber, passcode, notificationId, "technical-failure")


### PR DESCRIPTION
 - refactored notification status, changed numeric code to string notificationStatus