### PR TITLE
CAV-445: Standardise API responses - Verify endpoint to return status…

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyHelper.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/services/VerifyHelper.scala
@@ -100,7 +100,7 @@ abstract class VerifyHelper @Inject()(otpService: OtpService, auditService: Audi
         logger.error(error.getMessage)
         Result.apply(ResponseHeader(error.statusCode), HttpEntity.NoEntity)
     }
-    case Right(response) if response.status == 201 => Accepted(Json.toJson(NotificationId(response.json.as[GovUkNotificationId].id)))
+    case Right(response) if response.status == 201 => Accepted.withHeaders(("Location", s"/notifications/${response.json.as[GovUkNotificationId].id}"))
   } recover {
     case err =>
       logger.error(err.getMessage)

--- a/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/cipphonenumberverification/NotificationIntegrationSpec.scala
@@ -35,11 +35,11 @@ class NotificationIntegrationSpec
     "respond with 200 status with valid notification id" in {
       val verifyResponse = verify("07849123456").futureValue
 
-      val notificationId = verifyResponse.json.\("notificationId").as[String]
+      val notificationPath = verifyResponse.header("Location").get
 
       val response =
         wsClient
-          .url(s"$baseUrl/customer-insight-platform/phone-number/notifications/$notificationId")
+          .url(s"$baseUrl/customer-insight-platform/phone-number$notificationPath")
           .withRequestFilter(AhcCurlRequestLogger())
           .get
           .futureValue

--- a/test/uk/gov/hmrc/cipphonenumberverification/services/VerifyServiceSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberverification/services/VerifyServiceSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.Status._
 import play.api.libs.json.{Json, OWrites}
-import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, header, status}
 import uk.gov.hmrc.cipphonenumberverification.audit.AuditType.{PhoneNumberVerificationCheck, PhoneNumberVerificationRequest}
 import uk.gov.hmrc.cipphonenumberverification.audit.{VerificationCheckAuditEvent, VerificationRequestAuditEvent}
 import uk.gov.hmrc.cipphonenumberverification.connectors.{GovUkConnector, ValidateConnector}
@@ -51,7 +51,7 @@ class VerifyServiceSpec extends AnyWordSpec
       val result = verifyService.verifyPhoneNumber(enteredPhoneNumber)
 
       status(result) shouldBe ACCEPTED
-      (contentAsJson(result) \ "notificationId").as[String] shouldBe "test-notification-id"
+      header("Location", result) shouldBe Some("/notifications/test-notification-id")
 
       // check what is sent to validation service
       validateConnectorMock.callService("test")(any[HeaderCarrier]) was called


### PR DESCRIPTION
… endpoint url in the Location header

 - refactored verify response, replaced json body with Location header